### PR TITLE
feat: add seq-content command and seq-stats improvements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -276,6 +276,23 @@ pub enum Commands {
         #[clap(short = 'g', long)]
         genome_size: Option<usize>,
     },
+    /// Analyze k-mer content in genomic regions specified by a BED file.
+    ///
+    /// For each unique name in the 4th column of the BED file, counts k-mers
+    /// across all regions with that name and outputs a table with k-mer frequencies.
+    SeqContent {
+        /// Input FASTA file (can be compressed with .gz)
+        #[clap(short, long)]
+        fasta: String,
+
+        /// Input BED file with 4 columns (chr, start, end, name)
+        #[clap(short, long)]
+        bed: String,
+
+        /// K-mer length to analyze (must be <= 7)
+        #[clap(short, long, default_value_t = 3)]
+        kmer_size: usize,
+    },
 }
 
 pub fn make_cli_parse() -> Cli {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,4 +32,5 @@ pub mod bed_stats;
 
 //pub mod test;
 pub mod add_rg;
+pub mod seq_content;
 pub mod seq_stats;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use rust_htslib::faidx;
 use rustybam::cli::Commands;
 use rustybam::fastx;
 use rustybam::paf::paf_swap_query_and_target;
+use rustybam::seq_content;
 use rustybam::*;
 use std::time::Instant;
 
@@ -333,6 +334,23 @@ pub fn parse_cli() {
             name,
         }) => {
             getfasta::get_fasta(fasta, bed, *name, *strand);
+        }
+        //
+        // Run SeqContent
+        //
+        Some(Commands::SeqContent {
+            fasta,
+            bed,
+            kmer_size,
+        }) => {
+            if *kmer_size == 0 || *kmer_size > 7 {
+                eprintln!("Error: k-mer size must be 1-7, got {}", kmer_size);
+                std::process::exit(1);
+            }
+            if let Err(e) = seq_content::run_seq_content(fasta, bed, *kmer_size) {
+                eprintln!("Error running seq-content: {}", e);
+                std::process::exit(1);
+            }
         }
         //
         // no command opt

--- a/src/seq_content.rs
+++ b/src/seq_content.rs
@@ -1,0 +1,276 @@
+use super::bed;
+use rust_htslib::faidx;
+use std::collections::HashMap;
+
+/// Represents k-mer counts for a specific region category
+#[derive(Debug, Clone)]
+pub struct KmerCounts {
+    pub name: String,
+    pub kmer_counts: HashMap<String, u64>,
+}
+
+/// Generate reverse complement of a DNA sequence
+fn reverse_complement(seq: &str) -> String {
+    seq.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'T' => 'A',
+            'C' => 'G',
+            'G' => 'C',
+            _ => c,
+        })
+        .collect()
+}
+
+/// Get the canonical form of a k-mer (lexicographically smaller of k-mer and its reverse complement)
+fn canonical_kmer(kmer: &str) -> String {
+    let rc = reverse_complement(kmer);
+    if kmer <= rc.as_str() {
+        kmer.to_string()
+    } else {
+        rc
+    }
+}
+
+/// Generate all possible canonical k-mers of given length using DNA alphabet
+fn generate_all_kmers(k: usize) -> Vec<String> {
+    let bases = ['A', 'C', 'G', 'T'];
+    let mut kmers = vec!["".to_string()];
+
+    for _ in 0..k {
+        let mut new_kmers = Vec::new();
+        for kmer in &kmers {
+            for &base in &bases {
+                new_kmers.push(format!("{}{}", kmer, base));
+            }
+        }
+        kmers = new_kmers;
+    }
+
+    // Convert to canonical form and deduplicate
+    let mut canonical_kmers: Vec<String> = kmers
+        .into_iter()
+        .map(|kmer| canonical_kmer(&kmer))
+        .collect();
+
+    canonical_kmers.sort();
+    canonical_kmers.dedup();
+    canonical_kmers
+}
+
+/// Extract k-mers from a DNA sequence using canonical form
+fn extract_kmers(sequence: &[u8], k: usize) -> HashMap<String, u64> {
+    let mut kmer_counts = HashMap::new();
+
+    if sequence.len() < k {
+        return kmer_counts;
+    }
+
+    for i in 0..=(sequence.len() - k) {
+        let kmer_bytes = &sequence[i..i + k];
+
+        // Convert to uppercase and check if all bases are valid DNA
+        let kmer_str: Result<String, _> = kmer_bytes
+            .iter()
+            .map(|&b| match b.to_ascii_uppercase() {
+                b'A' | b'C' | b'G' | b'T' => Ok(b.to_ascii_uppercase() as char),
+                _ => Err(()),
+            })
+            .collect();
+
+        if let Ok(kmer) = kmer_str {
+            // Convert to canonical form (merge with reverse complement)
+            let canonical = canonical_kmer(&kmer);
+            *kmer_counts.entry(canonical).or_insert(0) += 1;
+        }
+        // Skip k-mers with invalid characters (N, etc.)
+    }
+
+    kmer_counts
+}
+
+/// Count k-mers in genomic regions specified by BED file
+pub fn count_kmers_in_regions(
+    fasta_path: &str,
+    bed_path: &str,
+    k: usize,
+) -> Result<Vec<KmerCounts>, Box<dyn std::error::Error>> {
+    // Parse BED file
+    let bed_regions = bed::parse_bed(bed_path);
+
+    // Open FASTA file
+    let fasta_reader = faidx::Reader::from_path(fasta_path)?;
+
+    // Group regions by chromosome, then by region name (4th column)
+    let mut regions_by_chrom: HashMap<String, Vec<&bed::Region>> = HashMap::new();
+    for region in &bed_regions {
+        regions_by_chrom
+            .entry(region.name.clone())
+            .or_default()
+            .push(region);
+    }
+
+    // Initialize results map for each unique region name
+    let mut results_map: HashMap<String, HashMap<String, u64>> = HashMap::new();
+    for region in &bed_regions {
+        results_map.entry(region.id.clone()).or_default();
+    }
+
+    // Process each chromosome
+    for (chrom, regions) in regions_by_chrom {
+        log::info!("Processing chromosome: {}", chrom);
+
+        // Fetch each region on its own. This avoids one whole-chromosome
+        // buffer per contig.
+        for region in regions {
+            let start = region.st as usize;
+            let end = region.en as usize;
+
+            if start >= end {
+                log::warn!("Invalid region coordinates: {}:{}-{}", chrom, start, end);
+                continue;
+            }
+
+            // fetch_seq takes an inclusive end position. rust-htslib 1.0
+            // returns an owned Vec and frees the htslib buffer itself.
+            let region_sequence = fasta_reader.fetch_seq(&chrom, start, end - 1)?;
+
+            // Count k-mers in this region
+            let region_kmers = extract_kmers(&region_sequence, k);
+
+            // Add to combined counts for this region name
+            let combined_counts = results_map.get_mut(&region.id).unwrap();
+            for (kmer, count) in region_kmers {
+                *combined_counts.entry(kmer).or_insert(0) += count;
+            }
+        }
+    }
+
+    // Convert results map to vector
+    let results: Vec<KmerCounts> = results_map
+        .into_iter()
+        .map(|(name, kmer_counts)| KmerCounts { name, kmer_counts })
+        .collect();
+
+    Ok(results)
+}
+
+/// Print k-mer counts in a tabular format
+pub fn print_kmer_results(results: &[KmerCounts], k: usize) {
+    if results.is_empty() {
+        return;
+    }
+
+    // Generate all possible k-mers for consistent column ordering
+    let all_kmers = generate_all_kmers(k);
+
+    // Sort results by region name alphabetically
+    let mut sorted_results = results.to_vec();
+    sorted_results.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // Print header
+    print!("name\ttotal_kmers");
+    for kmer in &all_kmers {
+        print!("\t{}", kmer);
+    }
+    println!();
+
+    // Print results for each region name in alphabetical order
+    for result in &sorted_results {
+        // Calculate total k-mer count
+        let total_count: u64 = result.kmer_counts.values().sum();
+
+        print!("{}\t{}", result.name, total_count);
+        for kmer in &all_kmers {
+            let count = result.kmer_counts.get(kmer).unwrap_or(&0);
+            print!("\t{}", count);
+        }
+        println!();
+    }
+}
+
+/// Main function to run seq-content analysis
+pub fn run_seq_content(
+    fasta_path: &str,
+    bed_path: &str,
+    k: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    log::info!("Analyzing {}-mer content in regions from {}", k, bed_path);
+    log::info!("Using FASTA file: {}", fasta_path);
+
+    let results = count_kmers_in_regions(fasta_path, bed_path, k)?;
+
+    log::info!("Found {} unique region names", results.len());
+
+    print_kmer_results(&results, k);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reverse_complement() {
+        assert_eq!(reverse_complement("ATCG"), "CGAT");
+        assert_eq!(reverse_complement("AAAA"), "TTTT");
+        assert_eq!(reverse_complement("GCGC"), "GCGC");
+    }
+
+    #[test]
+    fn test_canonical_kmer() {
+        assert_eq!(canonical_kmer("AAT"), "AAT"); // AAT < ATT
+        assert_eq!(canonical_kmer("ATT"), "AAT"); // ATT > AAT, so return AAT
+        assert_eq!(canonical_kmer("GGG"), "CCC"); // GGG > CCC, so return CCC
+        assert_eq!(canonical_kmer("ACG"), "ACG"); // ACG < CGT, so return ACG
+        assert_eq!(canonical_kmer("CGT"), "ACG"); // CGT > ACG, so return ACG
+    }
+
+    #[test]
+    fn test_generate_all_kmers() {
+        let kmers_2 = generate_all_kmers(2);
+        assert_eq!(kmers_2.len(), 10); // 16 - 6 pairs merged (AA, AC, AG, AT, CC, CG remain)
+        assert!(kmers_2.contains(&"AA".to_string()));
+        assert!(!kmers_2.contains(&"TT".to_string())); // TT should be merged with AA
+        assert!(kmers_2.contains(&"AC".to_string()));
+
+        let kmers_1 = generate_all_kmers(1);
+        assert_eq!(kmers_1.len(), 2); // A and C (T->A, G->C)
+        assert!(kmers_1.contains(&"A".to_string()));
+        assert!(kmers_1.contains(&"C".to_string()));
+        assert!(!kmers_1.contains(&"G".to_string())); // G should be merged with C
+        assert!(!kmers_1.contains(&"T".to_string())); // T should be merged with A
+    }
+
+    #[test]
+    fn test_extract_kmers() {
+        let sequence = b"ATCGATCG";
+        let kmers = extract_kmers(sequence, 3);
+
+        // With canonical k-mers:
+        // ATC (canonical: ATC, since ATC < GAT), TCG (canonical: CGA, since TCG > CGA),
+        // CGA (canonical: CGA), GAT (canonical: ATC, since GAT > ATC),
+        // ATC (canonical: ATC), TCG (canonical: CGA)
+        assert_eq!(kmers.get("ATC").unwrap_or(&0), &3); // ATC appears 2 times + GAT->ATC 1 time
+        assert_eq!(kmers.get("CGA").unwrap_or(&0), &3); // CGA appears 1 time + TCG->CGA 2 times
+    }
+
+    #[test]
+    fn test_extract_kmers_with_invalid_chars() {
+        let sequence = b"ATCNATCG";
+        let kmers = extract_kmers(sequence, 3);
+
+        // Should skip k-mers containing N
+        assert_eq!(kmers.get("TCN").unwrap_or(&0), &0);
+        assert_eq!(kmers.get("CNA").unwrap_or(&0), &0);
+        assert_eq!(kmers.get("NAT").unwrap_or(&0), &0);
+
+        // Should count valid k-mers in canonical form
+        // ATC appears 2 times (positions 0 and 5)
+        // TCG appears 1 time (position 6) -> canonical CGA
+        assert_eq!(kmers.get("ATC").unwrap_or(&0), &2);
+        assert_eq!(kmers.get("CGA").unwrap_or(&0), &1);
+    }
+}

--- a/src/seq_stats.rs
+++ b/src/seq_stats.rs
@@ -1,11 +1,13 @@
-use niffler::get_reader;
+use super::bed;
+use needletail::parse_fastx_file;
 use num_format::{Locale, ToFormattedString};
+use rayon::prelude::*;
 use rust_htslib::bam::{self, Read};
 use std::fs;
 use std::io::{self, BufRead};
+use std::path::Path;
 
-fn read_bam(file: &str, threads: usize) -> Option<(Vec<String>, Vec<usize>)> {
-    let mut names = Vec::new();
+fn read_bam(file: &str, threads: usize) -> Option<Vec<usize>> {
     let mut lengths = Vec::new();
 
     let mut bam = bam::Reader::from_path(file).ok()?;
@@ -13,36 +15,83 @@ fn read_bam(file: &str, threads: usize) -> Option<(Vec<String>, Vec<usize>)> {
     for record in bam.records() {
         let rec = record.ok()?;
         if rec.is_unmapped() || (!rec.is_secondary() && !rec.is_supplementary()) {
-            names.push(String::from_utf8_lossy(rec.qname()).to_string());
             lengths.push(rec.seq().len());
         }
     }
     eprintln!("SAM/BAM read: {}", file);
-    Some((names, lengths))
+    Some(lengths)
 }
 
-fn read_bed(file: &str) -> Option<(Vec<String>, Vec<usize>)> {
-    let mut names = Vec::new();
+fn read_bed(file: &str) -> Option<Vec<usize>> {
+    let regions = bed::parse_bed(file);
+    if regions.is_empty() {
+        return None;
+    }
+    Some(regions.iter().map(|r| (r.en - r.st) as usize).collect())
+}
+
+/// Read sequence lengths straight out of a `.fai` index, without touching the sequence data.
+fn read_fai(fai_path: &str) -> Option<Vec<usize>> {
+    let file = fs::File::open(fai_path).ok()?;
+    let reader = io::BufReader::new(file);
     let mut lengths = Vec::new();
-
-    let file = fs::File::open(file).ok()?;
-    let (reader, _compression) = get_reader(Box::new(file)).ok()?;
-    let reader = io::BufReader::new(reader);
-
     for line in reader.lines() {
         let line = line.ok()?;
-        if line.starts_with('#') {
-            continue;
-        }
-        let fields: Vec<&str> = line.split_whitespace().collect();
-        if fields.len() >= 3 {
-            let start: usize = fields[1].parse().ok()?;
-            let end: usize = fields[2].parse().ok()?;
-            names.push(fields[0].to_string());
-            lengths.push(end - start);
+        let len: usize = line.split('\t').nth(1)?.parse().ok()?;
+        lengths.push(len);
+    }
+    if lengths.is_empty() {
+        None
+    } else {
+        Some(lengths)
+    }
+}
+
+fn read_fasta_or_fastx(file: &str) -> Option<Vec<usize>> {
+    let fai_path = format!("{}.fai", file);
+    if Path::new(&fai_path).exists() {
+        if let Some(lengths) = read_fai(&fai_path) {
+            eprintln!("Index read: {}", file);
+            return Some(lengths);
         }
     }
-    Some((names, lengths))
+
+    let mut reader = parse_fastx_file(file).ok()?;
+    let mut lengths = Vec::new();
+    while let Some(record) = reader.next() {
+        match record {
+            Ok(rec) => lengths.push(rec.num_bases()),
+            Err(e) => log::warn!("Error reading record in {}: {}", file, e),
+        }
+    }
+    eprintln!("Fastx read: {}", file);
+    Some(lengths)
+}
+
+fn get_lengths(file: &str, threads: usize) -> Option<Vec<usize>> {
+    if file.ends_with(".bam") || file.ends_with(".sam") || file.ends_with(".cram") {
+        log::info!("Reading BAM/SAM/CRAM file: {}", file);
+        read_bam(file, threads)
+    } else if file.ends_with(".bed") || file.ends_with(".bed.gz") {
+        log::info!("Reading BED file: {}", file);
+        read_bed(file)
+    } else {
+        log::info!("Reading fasta/fastq file: {}", file);
+        read_fasta_or_fastx(file)
+    }
+}
+
+/// Linear-interpolation quantile, matching numpy's default `np.quantile` method.
+fn quantile(sorted_asc: &[usize], q: f64) -> f64 {
+    let n = sorted_asc.len();
+    if n == 0 {
+        return 0.0;
+    }
+    let h = q * (n - 1) as f64;
+    let lo = h.floor() as usize;
+    let hi = (h.ceil() as usize).min(n - 1);
+    let lo_v = sorted_asc[lo] as f64;
+    lo_v + (h - lo as f64) * (sorted_asc[hi] as f64 - lo_v)
 }
 
 fn calc_stats(
@@ -52,24 +101,20 @@ fn calc_stats(
 ) -> (usize, usize, f64, Vec<f64>, usize, usize, usize, f64) {
     let n = lengths.len();
     let total: usize = genome_size.unwrap_or_else(|| lengths.iter().sum());
-    let mut sorted_lengths = lengths.to_vec();
-    sorted_lengths.sort_unstable_by(|a, b| b.cmp(a));
+    let mut asc = lengths.to_vec();
+    asc.sort_unstable();
 
-    let max = *sorted_lengths.first().unwrap_or(&0);
-    let min = *sorted_lengths.last().unwrap_or(&0);
+    let min = *asc.first().unwrap_or(&0);
+    let max = *asc.last().unwrap_or(&0);
     let mean = total as f64 / n as f64;
 
-    let au_n: f64 = sorted_lengths.iter().map(|&x| (x * x) as f64).sum::<f64>() / total as f64;
+    let au_n: f64 = asc.iter().map(|&x| (x * x) as f64).sum::<f64>() / total as f64;
 
-    let mut quantile_values = Vec::new();
-    for &q in quantiles {
-        let idx = (q * n as f64).ceil() as usize - 1;
-        quantile_values.push(sorted_lengths.get(idx).cloned().unwrap_or(0) as f64);
-    }
+    let quantile_values: Vec<f64> = quantiles.iter().map(|&q| quantile(&asc, q)).collect();
 
     let mut cumulative = 0;
     let mut n50 = 0;
-    for &len in &sorted_lengths {
+    for &len in asc.iter().rev() {
         cumulative += len;
         if cumulative >= total / 2 {
             n50 = len;
@@ -94,6 +139,63 @@ where
     format!("{:.2}{}", num, "Gbp")
 }
 
+fn quantile_header_label(q: f64) -> String {
+    // Round to one decimal so 0.333 prints as 33.3%, not 33.300000000000004%.
+    let pct = (q * 1000.0).round() / 10.0;
+    format!("{}%", pct)
+}
+
+fn process_file(
+    file: &str,
+    threads: usize,
+    human_readable: bool,
+    quantiles: &[f64],
+    genome_size: Option<usize>,
+) -> Option<String> {
+    let lengths = get_lengths(file, threads);
+
+    let Some(lengths) = lengths else {
+        eprintln!("Skipping file: {}", file);
+        return None;
+    };
+
+    let (total, n, mean, quantile_values, min, max, n50, au_n) =
+        calc_stats(&lengths, quantiles, genome_size);
+
+    let quantile_str = quantile_values
+        .iter()
+        .map(|q| {
+            if human_readable {
+                h_fmt(*q)
+            } else {
+                format!("{:.2}", q)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\t");
+
+    let line = if human_readable {
+        format!(
+            "{}\t{}\t{}\t{:}\t{}\t{}\t{}\t{}\t{:}\n",
+            file,
+            h_fmt(total as f64),
+            n.to_formatted_string(&Locale::en),
+            h_fmt(mean),
+            quantile_str,
+            h_fmt(min as f64),
+            h_fmt(max as f64),
+            h_fmt(n50 as f64),
+            h_fmt(au_n)
+        )
+    } else {
+        format!(
+            "{}\t{}\t{}\t{:.2}\t{}\t{}\t{}\t{}\t{:.2}\n",
+            file, total, n, mean, quantile_str, min, max, n50, au_n
+        )
+    };
+    Some(line)
+}
+
 pub fn seq_stats(
     infiles: &[String],
     threads: usize,
@@ -101,60 +203,68 @@ pub fn seq_stats(
     quantiles: &[f64],
     genome_size: Option<usize>,
 ) {
-    let mut output = String::from("file\ttotalBp\tnSeqs\tmean\tquantiles\tmin\tmax\tN50\tauN\n");
+    let infiles: Vec<&String> = infiles
+        .iter()
+        .filter(|f| {
+            // Keep FIFOs and process substitutions. Skip only files
+            // that are missing, or regular and empty.
+            let exists_nonempty = fs::metadata(f.as_str())
+                .map(|m| !m.is_file() || m.len() > 0)
+                .unwrap_or(false);
+            if !exists_nonempty {
+                eprintln!("Skipping, because missing or empty: {}", f);
+            }
+            exists_nonempty
+        })
+        .collect();
 
-    for file in infiles {
-        let lengths = if file.ends_with(".bam") || file.ends_with(".sam") || file.ends_with(".cram")
-        {
-            log::info!("Reading BAM/SAM/CRAM file: {}", file);
-            read_bam(file, threads)
-        } else if file.ends_with(".bed") || file.ends_with(".bed.gz") {
-            log::info!("Reading BED file: {}", file);
-            read_bed(file)
-        } else {
-            None
-        };
+    let quantile_headers = quantiles
+        .iter()
+        .map(|&q| quantile_header_label(q))
+        .collect::<Vec<_>>()
+        .join("\t");
+    let mut output = format!(
+        "file\ttotalBp\tnSeqs\tmean\t{}\tmin\tmax\tN50\tauN\n",
+        quantile_headers
+    );
 
-        if let Some((_, lengths)) = lengths {
-            let (total, n, mean, quantile_values, min, max, n50, au_n) =
-                calc_stats(&lengths, quantiles, genome_size);
+    let rows: Vec<String> = infiles
+        .par_iter()
+        .filter_map(|file| process_file(file, threads, human_readable, quantiles, genome_size))
+        .collect();
 
-            let quantile_str = quantile_values
-                .iter()
-                .map(|q| {
-                    if human_readable {
-                        h_fmt(*q)
-                    } else {
-                        q.to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("\t");
-
-            let line = if human_readable {
-                format!(
-                    "{}\t{}\t{}\t{:}\t{}\t{}\t{}\t{}\t{:}\n",
-                    file,
-                    h_fmt(total as f64),
-                    n.to_formatted_string(&Locale::en),
-                    h_fmt(mean),
-                    quantile_str,
-                    h_fmt(min as f64),
-                    h_fmt(max as f64),
-                    h_fmt(n50 as f64),
-                    h_fmt(au_n)
-                )
-            } else {
-                format!(
-                    "{}\t{}\t{}\t{:.2}\t{}\t{}\t{}\t{}\t{:.2}\n",
-                    file, total, n, mean, quantile_str, min, max, n50, au_n
-                )
-            };
-            output.push_str(&line);
-        } else {
-            eprintln!("Skipping file: {}", file);
-        }
+    for row in rows {
+        output.push_str(&row);
     }
 
     print!("{}", output);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantile_matches_numpy_linear() {
+        assert_eq!(quantile(&[1, 2, 3, 4], 0.5), 2.5);
+        assert_eq!(quantile(&[1, 2, 3, 4], 0.0), 1.0);
+        assert_eq!(quantile(&[1, 2, 3, 4], 1.0), 4.0);
+    }
+
+    #[test]
+    fn reads_fasta_via_fai_fast_path() {
+        let lengths = read_fasta_or_fastx(".test/test.fa").expect("should read test.fa");
+        assert_eq!(lengths.len(), 2);
+    }
+
+    #[test]
+    fn reads_fasta_without_fai_via_needletail() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("rustybam_seq_stats_test.fa");
+        fs::write(&path, b">a\nACGT\n>b\nACGTACGT\n").unwrap();
+        let lengths =
+            read_fasta_or_fastx(path.to_str().unwrap()).expect("should read fasta via needletail");
+        assert_eq!(lengths, vec![4, 8]);
+        fs::remove_file(&path).ok();
+    }
 }


### PR DESCRIPTION
Adds the `rb seq-content` command. It counts canonical k-mers (k 1-7) in bed regions, grouped by the region name column, and prints one row per group with one column per canonical k-mer.

Also improves `rb seq-stats`: numpy-style linear-interpolation quantiles, clean one-decimal quantile headers, FIFO and process-substitution inputs, and skipping only missing or empty regular files.

Review status: a multi-agent review ran on this branch earlier. The confirmed findings are fixed in this tree: per-region fasta fetches instead of one whole-chromosome buffer per contig, k=0 rejected at the CLI, and the input prefilter keeps FIFOs.

Note on the rebase: the branch history was flattened onto main after the rust-htslib 1.0 migration. The earlier faidx free workaround is removed, because `fetch_seq` now returns an owned Vec and freeing its pointer would be a double free.